### PR TITLE
Add ability to fetch a dlmlock's events via the api (#29)

### DIFF
--- a/app/controllers/api/v2/dlmlock_events_controller.rb
+++ b/app/controllers/api/v2/dlmlock_events_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  module V2
+    class DlmlockEventsController < V2::BaseController
+      include Api::Version2
+
+      before_action :find_required_nested_object
+
+      api :GET, '/dlmlocks/:dlmlock_id/dlmlock_events', N_('List all events for a given DLM lock')
+      param :dlmlock_id, String, :desc => N_("ID of dlmlock")
+
+      def index
+        @events = resource_scope_for_index
+      end
+
+      def resource_class
+        ForemanDlm::DlmlockEvent
+      end
+
+      private
+
+      def action_permission
+        case params[:action]
+        when 'index'
+          :view
+        else
+          super
+        end
+      end
+
+      def allowed_nested_id
+        %w(dlmlock_id)
+      end
+
+      def resource_class_for(resource)
+        return ForemanDlm::Dlmlock if resource == 'dlmlock'
+        return ForemanDlm::DlmlockEvent if resource == 'dlmlock_event'
+        super
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/dlmlock_events_controller.rb
+++ b/app/controllers/api/v2/dlmlock_events_controller.rb
@@ -6,7 +6,7 @@ module Api
       before_action :find_required_nested_object
 
       api :GET, '/dlmlocks/:dlmlock_id/dlmlock_events', N_('List all events for a given DLM lock')
-      param :dlmlock_id, String, :desc => N_("ID of dlmlock")
+      param :dlmlock_id, String, :desc => N_('ID of dlmlock')
 
       def index
         @events = resource_scope_for_index
@@ -28,7 +28,7 @@ module Api
       end
 
       def allowed_nested_id
-        %w(dlmlock_id)
+        ['dlmlock_id']
       end
 
       def resource_class_for(resource)

--- a/app/controllers/api/v2/dlmlock_events_controller.rb
+++ b/app/controllers/api/v2/dlmlock_events_controller.rb
@@ -6,7 +6,7 @@ module Api
       before_action :find_required_nested_object
 
       api :GET, '/dlmlocks/:dlmlock_id/dlmlock_events', N_('List all events for a given DLM lock')
-      param :dlmlock_id, String, :desc => N_('ID of dlmlock')
+      param :dlmlock_id, String, :desc => N_('ID of DLM lock')
 
       def index
         @events = resource_scope_for_index

--- a/app/controllers/api/v2/dlmlocks_controller.rb
+++ b/app/controllers/api/v2/dlmlocks_controller.rb
@@ -11,7 +11,7 @@ module Api
       authorize_host_by_client_cert [:show, :release, :acquire]
       update_host_checkin_time [:show, :release, :acquire]
 
-      before_action :find_resource, :only => [:show, :update, :destroy, :events]
+      before_action :find_resource, :only => [:show, :update, :destroy]
       before_action :find_resource_or_create, :only => [:release, :acquire]
       before_action :find_host, :only => [:release, :acquire]
       before_action :setup_search_options, :only => [:index]
@@ -119,8 +119,6 @@ module Api
 
       def action_permission
         case params[:action]
-        when 'events'
-          :view
         when 'release', 'acquire'
           :edit
         else

--- a/app/controllers/api/v2/dlmlocks_controller.rb
+++ b/app/controllers/api/v2/dlmlocks_controller.rb
@@ -11,7 +11,7 @@ module Api
       authorize_host_by_client_cert [:show, :release, :acquire]
       update_host_checkin_time [:show, :release, :acquire]
 
-      before_action :find_resource, :only => [:show, :update, :destroy]
+      before_action :find_resource, :only => [:show, :update, :destroy, :events]
       before_action :find_resource_or_create, :only => [:release, :acquire]
       before_action :find_host, :only => [:release, :acquire]
       before_action :setup_search_options, :only => [:index]
@@ -119,6 +119,8 @@ module Api
 
       def action_permission
         case params[:action]
+        when 'events'
+          :view
         when 'release', 'acquire'
           :edit
         else

--- a/app/models/foreman_dlm/dlmlock_event.rb
+++ b/app/models/foreman_dlm/dlmlock_event.rb
@@ -14,6 +14,8 @@ module ForemanDlm
     belongs_to :dlmlock, inverse_of: :dlmlock_events, class_name: 'ForemanDlm::Dlmlock'
     belongs_to :user, inverse_of: :dlmlock_events
 
+    scoped_search on: :event_type, complete_value: true
+
     def humanized_type
       _('Dlmlock Event')
     end

--- a/app/views/api/v2/dlmlock_events/index.json.rabl
+++ b/app/views/api/v2/dlmlock_events/index.json.rabl
@@ -1,0 +1,2 @@
+collection @events
+attributes :id, :event_type, :created_at, :updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,12 @@ Rails.application.routes.draw do
                      :constraints => ApiConstraints.new(:version => 2, :default => true) do
       constraints(id: /[^\/]+/) do
         resources :dlmlocks, only: [:index, :show, :update, :destroy] do
+          resources :dlmlock_events, only: [:index]
+
           get :lock, on: :member, action: :show, controller: 'dlmlocks'
           put :lock, on: :member, action: :acquire, controller: 'dlmlocks'
           delete :lock, on: :member, action: :release, controller: 'dlmlocks'
+
         end
       end
       resources :dlmlocks, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Rails.application.routes.draw do
           get :lock, on: :member, action: :show, controller: 'dlmlocks'
           put :lock, on: :member, action: :acquire, controller: 'dlmlocks'
           delete :lock, on: :member, action: :release, controller: 'dlmlocks'
-
         end
       end
       resources :dlmlocks, only: [:create]

--- a/lib/foreman_dlm/engine.rb
+++ b/lib/foreman_dlm/engine.rb
@@ -31,7 +31,7 @@ module ForemanDlm
         security_block :foreman_dlm do
           permission :view_dlmlocks, {
             :'foreman_dlm/dlmlocks' => [:index, :show, :auto_complete_search],
-            :'api/v2/dlmlocks' => [:index, :show]
+            :'api/v2/dlmlocks' => [:index, :show, :events]
           }, :resource_type => 'ForemanDlm::Dlmlock'
 
           permission :create_dlmlocks, {
@@ -48,7 +48,9 @@ module ForemanDlm
             :'api/v2/dlmlocks' => [:destroy]
           }, :resource_type => 'ForemanDlm::Dlmlock'
 
-          permission :view_dlmlock_events, {}, :resource_type => 'ForemanDlm::DlmlockEvent'
+          permission :view_dlmlock_events, {
+            :'api/v2/dlmlock_events' => [:index]
+          }, :resource_type => 'ForemanDlm::DlmlockEvent'
         end
 
         # Add a new role called 'Distributed Lock Manager' if it doesn't exist

--- a/lib/foreman_dlm/engine.rb
+++ b/lib/foreman_dlm/engine.rb
@@ -31,7 +31,7 @@ module ForemanDlm
         security_block :foreman_dlm do
           permission :view_dlmlocks, {
             :'foreman_dlm/dlmlocks' => [:index, :show, :auto_complete_search],
-            :'api/v2/dlmlocks' => [:index, :show, :events]
+            :'api/v2/dlmlocks' => [:index, :show]
           }, :resource_type => 'ForemanDlm::Dlmlock'
 
           permission :create_dlmlocks, {

--- a/test/controllers/api/v2/dlmlocks_dlmlock_events_controller_test.rb
+++ b/test/controllers/api/v2/dlmlocks_dlmlock_events_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_plugin_helper'
+
+class Api::V2::DlmlockEventsControllerTest < ActionController::TestCase
+  let(:host) { as_admin { FactoryBot.create(:host, :managed) } }
+
+  context 'with user authentication' do
+    context '#index' do
+      test 'should return the dlmlock_events for a given dlm_lock' do
+        expected_size = 3
+
+        # A random dlmlock with events, that should not be in the response.
+        dlmlock1 = FactoryBot.create(:dlmlock, :host => host)
+        FactoryBot.create_list(:dlmlock_event, 2, dlmlock: dlmlock1)
+
+        dlmlock = FactoryBot.create(:dlmlock, :host => host)
+        FactoryBot.create_list(:dlmlock_event, expected_size, dlmlock: dlmlock)
+
+        expected_ids = dlmlock.dlmlock_events.pluck(:id).sort
+        expected_keys = ['id', 'event_type', 'created_at', 'updated_at']
+
+        get :index, params: { dlmlock_id: dlmlock.id }
+        assert_response :success
+
+        body = ActiveSupport::JSON.decode(@response.body)
+        assert_equal expected_size, body['total']
+        assert_equal expected_keys, body['results'].first.keys
+        assert_equal expected_ids, body['results'].map { |event| event['id'] }.sort
+      end
+    end
+  end
+
+  context 'without any credentials' do
+    setup do
+      User.current = nil
+      reset_api_credentials
+    end
+
+    context '#index' do
+      test 'should deny access' do
+        dlmlock = as_admin { FactoryBot.create(:dlmlock) }
+        get :index, params: { :dlmlock_id => dlmlock.id }
+        assert_response :unauthorized
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/dlmlocks_dlmlock_events_controller_test.rb
+++ b/test/controllers/api/v2/dlmlocks_dlmlock_events_controller_test.rb
@@ -9,10 +9,10 @@ class Api::V2::DlmlockEventsControllerTest < ActionController::TestCase
         expected_size = 3
 
         # A random dlmlock with events, that should not be in the response.
-        dlmlock1 = FactoryBot.create(:dlmlock, :host => host)
+        dlmlock1 = FactoryBot.create(:dlmlock, host: host)
         FactoryBot.create_list(:dlmlock_event, 2, dlmlock: dlmlock1)
 
-        dlmlock = FactoryBot.create(:dlmlock, :host => host)
+        dlmlock = FactoryBot.create(:dlmlock, host: host)
         FactoryBot.create_list(:dlmlock_event, expected_size, dlmlock: dlmlock)
 
         expected_ids = dlmlock.dlmlock_events.pluck(:id).sort
@@ -29,6 +29,42 @@ class Api::V2::DlmlockEventsControllerTest < ActionController::TestCase
     end
   end
 
+  context 'as user with required permissions' do
+    let(:permissions) { Permission.where(name: ['view_dlmlocks', 'view_dlmlock_events']) }
+    let(:role) { FactoryBot.create(:role, permissions: permissions) }
+    let(:user) { FactoryBot.create(:user, roles: [role]) }
+
+    setup do
+      User.current = user
+      reset_api_credentials
+    end
+
+    context '#index' do
+      test 'should allow access' do
+        dlmlock = as_admin { FactoryBot.create(:dlmlock) }
+        get :index, params: { dlmlock_id: dlmlock.id }
+        assert_response :success
+      end
+    end
+  end
+
+  context 'as user without required permissions' do
+    let(:user) { FactoryBot.create(:user, roles: []) }
+
+    setup do
+      User.current = user
+      reset_api_credentials
+    end
+
+    context '#index' do
+      test 'should deny access' do
+        dlmlock = as_admin { FactoryBot.create(:dlmlock) }
+        get :index, params: { dlmlock_id: dlmlock.id }
+        assert_response :forbidden
+      end
+    end
+  end
+
   context 'without any credentials' do
     setup do
       User.current = nil
@@ -38,7 +74,7 @@ class Api::V2::DlmlockEventsControllerTest < ActionController::TestCase
     context '#index' do
       test 'should deny access' do
         dlmlock = as_admin { FactoryBot.create(:dlmlock) }
-        get :index, params: { :dlmlock_id => dlmlock.id }
+        get :index, params: { dlmlock_id: dlmlock.id }
         assert_response :unauthorized
       end
     end


### PR DESCRIPTION
closes #29 

This patch adds a single endpoint `GET /dlmlocks/:id/events` which returns the dlmlock_events for a given dlmlock.