### PR TITLE
fix documentation link

### DIFF
--- a/app/views/foreman_dlm/dlmlocks/welcome.html.erb
+++ b/app/views/foreman_dlm/dlmlocks/welcome.html.erb
@@ -6,9 +6,9 @@
   <p>
   <%= _('You don\'t seem to have any locks.') %></br>
   <%= _('The distributed lock manager allows you to automatically schedule system updates across a cluster of hosts.') %>
-  <%= link_to _('Learn more about this in the documentation.'), 'https://github.com/timogoebel/foreman_dlm', :rel => "external" %>.
+  <%= link_to _('Learn more about this in the documentation.'), 'https://github.com/dm-drogeriemarkt/foreman_dlm', :rel => "external" %>.
   </p>
   <div class="blank-slate-pf-main-action">
-    <%= link_to _('Documentation'), 'https://github.com/timogoebel/foreman_dlm', :rel => 'external', :class => 'btn btn-primary btn-lg' %>
+    <%= link_to _('Documentation'), 'https://github.com/dm-drogeriemarkt/foreman_dlm', :rel => 'external', :class => 'btn btn-primary btn-lg' %>
   </div>
 </div>


### PR DESCRIPTION
The link is still pointing to the old repository which is now behind master.